### PR TITLE
Fix gdml_solids.xsd with duplicate element description

### DIFF
--- a/python/gegede/export/gdml/schema/gdml_solids.xsd
+++ b/python/gegede/export/gdml/schema/gdml_solids.xsd
@@ -24,21 +24,6 @@
   </xs:complexType>
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 	
-  <xs:element name="eltube" substitutionGroup="Solid">
-    <xs:annotation>
-      <xs:documentation>Ellispoid tube</xs:documentation>
-    </xs:annotation>
-    <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="SolidType">
-          <xs:attribute name="dx" type="ExpressionOrIDREFType" use="required"></xs:attribute>
-          <xs:attribute name="dy" type="ExpressionOrIDREFType" use="required"></xs:attribute>
-          <xs:attribute name="dz" type="ExpressionOrIDREFType" use="required"></xs:attribute>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-  </xs:element>
-  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->	
   
   <xs:complexType name="BooleanSolidType">
     <xs:annotation>


### PR DESCRIPTION
The test scripts are failing because of a problem in commit 50abeb4.  This defined the eltube element twice and failed the GDML validation.  

This change fixes the problem so the tests are passed.  The two eltube definitions are identical so the most recent is removed. 