### PR TITLE
feature/Add Material Properties

### DIFF
--- a/doc/construction.org
+++ b/doc/construction.org
@@ -41,7 +41,61 @@ Items to note about this example:
 - Unspecified arguments will take values as are provided by the schema, knowing these defaults lets it be said that the three boxes are equivalently defined.
 - All numerical quantities that have dimension *must* have units, while unitless quantities can be expressed as literal numbers or their string representations.  Either way, these values are parsed by [[https://github.com/hgrecco/pint][pint]] and must match the dimension for the value as given by its prototype in the schema.  Otherwise, one is free to specify values in whatever supported unit happens to be convenient.
 
-** Material
+** Materials
+
+Materials are defined using the geometry =matter= attribute.  There are two main classes of matter that can be defined.  In all cases, elements and materials must have unique names.
+
+The first type of matter describes elements, and compositions of isotopes.  These are described by the atomic number (Z), and the atomic mass.  For an element, the atomic mass is the average atomic mass of the element.  A composition is composed of one or more isotopes.  
+
+#+BEGIN_SRC python
+elem_hydrogen= geom.matter.Element("Elem_Hydrogen",z=1,a="1.008 g/mole")
+elem_helium = geom.matter.Element("Elem_Helium",z=2,a="4.003 g/mole")
+elem_oxygen = geom.matter.Element("Elem_Oxygen",z=8,a="15.999 g/mole")
+
+iso_helium3 = geom.matter.Isotope("Iso_Helium3",z=2,ia=3,a="3.016 g/mole")
+iso_helium4 = geom.matter.Isotope("Iso_Helium4",z=2,ia=4,a="4.003 g/mole")
+comp_helium = geom.matter.Composition("Comp_Helium",
+                                      isotopes=(("Iso_Helium3", 0.000002),
+                                                ("Iso_Helium4", 0.999998)))
+#+END_SRC
+
+The second type of matter describes materials that are used in simulations (e.g. "air", "water", "steel").  These materials are composed of elements, and other materials, and are defined using =Molecule=, =Mixture=, and =Amalgam=.
+
+A =Molecule= defines a specific molecule composed of elements or compositions of isotopes.  It is defined by the number of each element that occur in a single molecule, and comprises one or more elements.  For example, gaseous helium will have a single element while liquid water has two.
+
+#+BEGIN_SRC python
+helium = geom.matter.Molecule("Helium_Gas", density="0.1786 g/cc",
+                              elements = (("Elem_Helium",1)))
+water = geom.matter.Molecule("Water_Liquid", density="1.0 kg/l",
+                             elements = (("Elem_Hydrogen", 2)
+                                         ("Elem_Oxygen", 1)))
+#+END_SRC
+
+A =Mixture= defines a combination of elements and other materials.  Mixtures are defined by the mass fraction of each component.  For example, oxygenated water could be defined as
+
+#+BEGIN_SRC python
+aquarium_water = geom.matter.Mixture("Aquarium_Water", density="1.0 kg/l",
+                                     components = (("Elem_Oxygen", 0.01),
+                                                   ("Water_Liquid", 0.99)))
+#+END_SRC
+
+
+An =Amalgam= defines a material with no specific elemental components.  It is defined by it's effective atomic number, and it's effective atomic mass.  For example, an amalgam for water might be
+
+#+BEGIN_SRC python
+amalgam_water = geom.matter.Amalgam("Amal_Water", density = "1.0 kg/l",
+                                    z="7.42", a="18.02 g/mole")
+#+END_SRC
+
+Specific material properties can be defined for materials defined by =Molecule=, =Mixture=, and =Amalgam=.  These properties are used to fill the material property table for a material in GEANT4.  An example of defining the property for water is
+
+#+BEGIN_SRC python
+water = geom.matter.Molecule("Water_Liquid", density="1.0 kg/l",
+                             elements = (("Elem_Hydrogen", 2)
+                                         ("Elem_Oxygen", 1)),
+                             properties = (("ABSLENGTH", (20.0, 30.0)),
+                                           ("DIFFUSION", (1.0,))))
+#+END_SRC
 
 ** Volumes
 

--- a/python/gegede/export/gdml/__init__.py
+++ b/python/gegede/export/gdml/__init__.py
@@ -85,12 +85,20 @@ def make_material_node(obj):
         # fixme: units???
         node.append(etree.Element('D', value=D(obj)))
         node.append(etree.Element('atom', value=Atom(obj)))
+        for propname, propvect in obj.properties:
+            node.append(etree.Element('property',
+                                      name=propname,
+                                      ref=obj.name+'_'+propname+'_VALUE'))
 
     if typename == 'Molecule':
         node = etree.Element('material', name=obj.name, formula=Symbol(obj))
         node.append(etree.Element('D', value=D(obj)))
         for elename, elenum in obj.elements:
             node.append(etree.Element('composite', ref=elename, n=str(elenum)))
+        for propname, propvect in obj.properties:
+            node.append(etree.Element('property',
+                                      name=propname,
+                                      ref=obj.name+'_'+propname+'_VALUE'))
 
 
     if typename == 'Mixture':
@@ -98,6 +106,10 @@ def make_material_node(obj):
         node.append(etree.Element('D', value=D(obj)))
         for compname, compfrac in obj.components:
             node.append(etree.Element('fraction', ref=compname, n=str(compfrac)))
+        for propname, propvect in obj.properties:
+            node.append(etree.Element('property',
+                                      name=propname,
+                                      ref=obj.name+'_'+propname+'_VALUE'))
 
     return node
 
@@ -271,6 +283,19 @@ def convert(geom):
                 identity = obj
         if node is not None:
             define_node.append(node)
+        continue
+    for name, obj in geom.store.matter.items():
+        typename = type(obj).__name__.lower()
+        if typename=='mixture' or typename=='molecule' or typename=='amalgam':
+            for prop, val in obj.properties:
+                vals = str(val[0])
+                for v in val[1:]: vals += ' ' + str(v)
+                define_node.append(etree.Element('matrix',
+                                                 name=name+'_'+prop+'_VALUE',
+                                                 coldim=str(len(val)),
+                                                 values=vals))
+                continue
+            continue
         continue
     if center is None:
         define_node.append(etree.Element('position', name='center'))

--- a/python/gegede/schema/__init__.py
+++ b/python/gegede/schema/__init__.py
@@ -64,7 +64,7 @@ Schema = dict(
         Composition = (("symbol",str), ("isotopes", NamedTypedList(float))),
 
         # a material with no specific constituents
-        Amalgam = (("z", int),
+        Amalgam = (("z", float),
                    ("a","0.0g/mole"),
                    ("density", "0.0g/cc"), 
                    ("properties",NamedTypedList(list))),

--- a/python/gegede/schema/__init__.py
+++ b/python/gegede/schema/__init__.py
@@ -64,14 +64,23 @@ Schema = dict(
         Composition = (("symbol",str), ("isotopes", NamedTypedList(float))),
 
         # a material with no specific constituents
-        Amalgam = (("z", int), ("a","0.0g/mole"), ("density", "0.0g/cc")),
+        Amalgam = (("z", int),
+                   ("a","0.0g/mole"),
+                   ("density", "0.0g/cc"), 
+                   ("properties",NamedTypedList(list))),
 
         # A molecule is a Material with a number of elements
-        Molecule = (("symbol",str), ("density", "0.0g/cc"), ("elements", NamedTypedList(int))),
+        Molecule = (("symbol",str),
+                    ("density", "0.0g/cc"),
+                    ("elements", NamedTypedList(int)),
+                    ("properties",NamedTypedList(list))),
 
         # A mixture is a Material that has a number of elements or
         # other materials added by mass fraction.
-        Mixture = (("symbol",str), ("density", "0.0g/cc"), ("components", NamedTypedList(float))),
+        Mixture = (("symbol",str),
+                   ("density", "0.0g/cc"),
+                   ("components", NamedTypedList(float)),
+                   ("properties", NamedTypedList(list))),
 
         # fixme, these need to also take state, temperature and pressure, radlen
         ),

--- a/tests/test_matter.py
+++ b/tests/test_matter.py
@@ -7,18 +7,38 @@ def test_air():
     n = g.matter.Element("Nitrogen", "N", 7, "14.01*g/mole")
     o = g.matter.Element("Oxygen", "O", 8, "16.0g/mole")
     air = g.matter.Mixture("Air", density = "1.290*mg/cc", 
-                           components = (("Nitrogen", 0.7), ("Oxygen",0.3)))
+                           components = (("Nitrogen", 0.7), ("Oxygen",0.3)),
+                           properties = (("PCONST", (1.0,)),
+                                         ("PVECTOR", (1.0, 2.0))))
     print (air)
     assert len(air.components) == 2
     assert type(air.components[0]) == tuple
+    assert type(air.properties[0]) == tuple
 
 
 def test_water():
     g = gegede.construct.Geometry()
     h = g.matter.Element("Hydrogen","H",1,"1.01g/mole")
     o = g.matter.Element("Oxygen", "O", 8, "16.0g/mole")
-    water = g.matter.Molecule("Water", density="1.0kg/l", elements=(("Oxygen",1),("Hydrogen",2)))
+    water = g.matter.Molecule("Water", density="1.0kg/l",
+                              elements=(("Oxygen",1),("Hydrogen",2)),
+                              properties = (("PCONST", (1.0,)),
+                                            ("PVECTOR", (1.0, 2.0))))
     print (water)
     assert len(water.elements) == 2
     assert type(water.elements[0]) == tuple
+    assert type(water.properties[0]) == tuple
+    
+
+def test_earth():
+    g = gegede.construct.Geometry()
+    averageZ = 14.58
+    earth = g.matter.Amalgam("Water", density="1.0kg/l",
+                             z=averageZ, a="28.085 g/mole",
+                             properties = (("PCONST", (1.0,)),
+                                           ("PVECTOR", (1.0, 2.0))))
+    print (earth)
+    assert earth.z == averageZ
+    assert type(earth.properties[0]) == tuple
+    
     


### PR DESCRIPTION
This collection of commits adds the ability to define material properties.  These are useful for defining the GEANT4 material property  tables.  This makes changes to the gegede schema, and adds the necessary GDML export code.  It also adds documentation to construction.org describing how materials are defined.

It includes one fix to the gegede scheme so that an Amalgam can have a non-integer effective atomic number.